### PR TITLE
build(deps): bump Go version to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Release versions use distroless images built via GoReleaser with ko
 # See .goreleaser.yml
 #
-FROM golang:1.26.5 AS build
+FROM golang:1.26.6 AS build
 WORKDIR /app
 RUN curl -sL https://taskfile.dev/install.sh | sh
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veerendra2/speedtest_exporter
 
-go 1.26.3
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.1


### PR DESCRIPTION
## Overview
Bumps Go version from `1.26.3` to the latest stable release **`1.26.6`**.

## Changes
- **`go.mod`**: Bumped Go directive from `go 1.26.3` -> `go 1.26.6`.
- **`Dockerfile`**: Bumped builder image from `golang:1.26.5` -> `golang:1.26.6`.

<p align="right"><sub>~ chitragupta</sub></p>
