### PR TITLE
build(deps): bump Go version to 1.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Release versions use distroless images built via GoReleaser with ko
 # See .goreleaser.yml
 #
-FROM golang:1.26.6 AS build
+FROM golang:1.27.0 AS build
 WORKDIR /app
 RUN curl -sL https://taskfile.dev/install.sh | sh
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veerendra2/speedtest_exporter
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/alecthomas/kong v1.16.1


### PR DESCRIPTION
## Overview
Bumps Go version to the latest stable release **`1.27.0`**.

## Changes
- **`go.mod`**: Updated Go directive to `go 1.27.0`.

<p align="right"><sub>~ chitragupta</sub></p>
